### PR TITLE
[Fixed] Change keymap for Windows

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,10 +1,10 @@
 [
     {
-        "keys": ["ctrl+k", "ctrl+a"],
+        "keys": ["ctrl+k", "ctrl+super+a"],
         "command": "super_navigate"
     },
     {
-        "keys": ["ctrl+k", "ctrl+s"],
+        "keys": ["ctrl+k", "ctrl+super+s"],
         "command": "super_navigate",
         "args": { "allTabs": true }
     }


### PR DESCRIPTION
See [**my comment**](https://github.com/jugyo/SublimeSuperNavigator/pull/3#issuecomment-270604207) to previous pull request. It is bad practice to rewrite default keymap, because users needs to make actions, if they want to run default commands by hotkeys.

<kbd>Ctrl+Super+A</kbd> and <kbd>Ctrl+Super+S</kbd> is not default [**Windows**](https://support.microsoft.com/en-us/help/12445/windows-keyboard-shortcuts) and [**Sublime Text**](https://github.com/bradrobertson/sublime-packages/blob/master/Default/Default%20(Windows).sublime-keymap#L551) hotkeys.

Thanks.